### PR TITLE
Provided the path to the right repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
 			if( !remotes.contains('github') )
 			{
 				echo 'Adding github remote'
-				powershell script:'git remote add github https://github.com/SeredaOM/JenkinsLearning.git'
+				powershell script:'git remote add github https://github.com/SeredaOM/AngularLearning.git'
 				powershell script:'git fetch github master'
 			}
 					


### PR DESCRIPTION
A more universal way would be to pull the repo url to be added
from the list of remotes.