### PR TITLE
Restore version in package.json

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-example",
-  "version": "0.1.",
+  "version": "0.1.999",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,11 +65,7 @@ pipeline {
             def packageFilePath = './package.json'
             def props = readJSON file: packageFilePath, returnPojo: true
             def version = new String(props['version'].value)
-            echo "org version: "+version
-            def idx=version.lastIndexOf('.')
-            echo "idx: "+idx
-            def versionCut = version.substring(0, idx+1)
-            echo "cut version: "+versionCut
+            def versionCut = version.substring(0, version.lastIndexOf('.')+1)
             props['version'] = versionCut + buildNumberString
             echo "updated props: " + props
             writeJSON file: packageFilePath, json: props

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,11 @@ pipeline {
 
             def packageFilePath = './package.json'
             def props = readJSON file: packageFilePath, returnPojo: true
-            props['version'] = new String(props['version'].value) + buildNumberString
+            def version = new String(props['version'].value)
+            echo "org version: "+version
+            def versionCut = version.substring(0, version.lastIndexOf('.'+1))
+            echo "cut version: "+versionCut
+            props['version'] = versionCut + buildNumberString
             echo "updated props: " + props
             writeJSON file: packageFilePath, json: props
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,9 @@ pipeline {
             def props = readJSON file: packageFilePath, returnPojo: true
             def version = new String(props['version'].value)
             echo "org version: "+version
-            def versionCut = version.substring(0, version.lastIndexOf('.'+1))
+            def idx=version.lastIndexOf('.')
+            echo "idx: "+idx
+            def versionCut = version.substring(0, idx+1)
             echo "cut version: "+versionCut
             props['version'] = versionCut + buildNumberString
             echo "updated props: " + props


### PR DESCRIPTION
If version in package.json is not valid Angular application won't build.
It has to be valid outside of the CI, so during the CI we need to cut and replace the last digit.